### PR TITLE
feat: added cacheParameterGroupName variable support

### DIFF
--- a/API.md
+++ b/API.md
@@ -149,6 +149,7 @@ const redisDBProps: RedisDBProps = { ... }
 | [`nodes`](#cdkredisdbredisdbpropspropertynodes) | `number` | *No description.* |
 | [`nodesCpuAutoscalingTarget`](#cdkredisdbredisdbpropspropertynodescpuautoscalingtarget) | `number` | *No description.* |
 | [`nodeType`](#cdkredisdbredisdbpropspropertynodetype) | `string` | *No description.* |
+| [`parameterGroupName`](#cdkredisdbredisdbpropspropertyparametergroupname) | `string` | *No description.* |
 | [`replicas`](#cdkredisdbredisdbpropspropertyreplicas) | `number` | *No description.* |
 | [`replicasCpuAutoscalingTarget`](#cdkredisdbredisdbpropspropertyreplicascpuautoscalingtarget) | `number` | *No description.* |
 | [`subnetGroupName`](#cdkredisdbredisdbpropspropertysubnetgroupname) | `string` | *No description.* |
@@ -343,6 +344,16 @@ public readonly nodesCpuAutoscalingTarget: number;
 
 ```typescript
 public readonly nodeType: string;
+```
+
+- *Type:* `string`
+
+---
+
+##### `parameterGroupName`<sup>Optional</sup> <a name="cdk-redisdb.RedisDBProps.property.parameterGroupName" id="cdkredisdbredisdbpropspropertyparametergroupname"></a>
+
+```typescript
+public readonly parameterGroupName: string;
 ```
 
 - *Type:* `string`

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export interface RedisDBProps extends StackProps {
   readonly atRestEncryptionEnabled?: boolean | IResolvable;
   readonly transitEncryptionEnabled?: boolean | IResolvable;
   readonly engineVersion?: string;
+  readonly parameterGroupName?: string;
   readonly memoryAutoscalingTarget?: number;
   readonly replicasCpuAutoscalingTarget?: number;
   readonly nodesCpuAutoscalingTarget?: number;
@@ -82,7 +83,7 @@ export class RedisDB extends Construct {
       engine: 'Redis',
       multiAzEnabled: false,
       autoMinorVersionUpgrade: false,
-      cacheParameterGroupName: 'default.redis6.x.cluster.on',
+      cacheParameterGroupName: props.parameterGroupName ?? 'default.redis6.x.cluster.on',
       engineVersion: props.engineVersion ?? '6.x',
       cacheSubnetGroupName: groupName,
       securityGroupIds: [ecSecurityGroup.securityGroupId],


### PR DESCRIPTION
Added support for not-the-latest redis versions by introducing props.parameterGroupName to be able to use different group names from the https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/ParameterGroups.Redis.html