### PR TITLE
feat: Add `port` property.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ export interface RedisDBProps extends StackProps {
   readonly replicas?: number;
   readonly authToken?: string;
   readonly subnetGroupName?: string;
+  readonly port?: number;
 }
 
 function setupVpc(parent: any, props: RedisDBProps) : ec2.IVpc {
@@ -99,6 +100,7 @@ export class RedisDB extends Construct {
       transitEncryptionEnabled: props.transitEncryptionEnabled,
       replicasPerNodeGroup: props.replicas || 0,
       authToken: props.authToken,
+      port: props.port || 6379,
     });
     this.replicationGroup = redis_cluster;
     if (!props.existingSubnetGroupName) {
@@ -207,6 +209,7 @@ export class MemoryDB extends Construct {
       securityGroupIds: [ecSecurityGroup.securityGroupId],
       subnetGroupName: groupName,
       tlsEnabled: true,
+      port: props.port || 6379,
     });
     if (!props.existingSubnetGroupName) {
       memorydb_cluster.node.addDependency(ecSubnetGroup!);


### PR DESCRIPTION
This allows specifying the port of the Redis cluster.  If the port isn't specified, the cfn attributes for the ports are `Token`s, which aren't knowable at synth time.  I need to know the port during synth, so I can put the value in an environment variable for my service to pick up.