### PR TITLE
feat: disable TLS if transitEncryptionEnabled provided in MemoryDB

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -206,7 +206,7 @@ export class MemoryDB extends Construct {
       numReplicasPerShard: props.replicas||0,
       securityGroupIds: [ecSecurityGroup.securityGroupId],
       subnetGroupName: groupName,
-      tlsEnabled: true,
+      tlsEnabled: props.transitEncryptionEnabled ?? true,
     });
     if (!props.existingSubnetGroupName) {
       memorydb_cluster.node.addDependency(ecSubnetGroup!);


### PR DESCRIPTION
Make the transitEncryptionEnabled parameter works in MemoryDB as well.